### PR TITLE
Update the FamilySearch/FindAGrave query params

### DIFF
--- a/findagrave-extras.user.js
+++ b/findagrave-extras.user.js
@@ -165,11 +165,12 @@ class FamilySearchTreeQuery {
 class FamilySearchFindAGraveQuery {
   constructor(memorial) { this.memorial = memorial }
   static rootUrl = "https://www.familysearch.org/search/record/results";
+  static collectionId = "2221801";
 
   get url() {
     return `${FamilySearchFindAGraveQuery.rootUrl}?` +
-      `external_record_id=${this.memorial.memorialId}&` +
-      "collection_id=2221801";
+      `q.externalRecordId=${this.memorial.memorialId}&` +
+      `f.collectionId=${FamilySearchFindAGraveQuery.collectionId}`;
   }
 }
 


### PR DESCRIPTION
Familysearch changed the parameters for their Find-A-Grave query.