### PR TITLE
Derive birth (maiden) names from Find-A-Grave pages

### DIFF
--- a/findagrave-extras.user.js
+++ b/findagrave-extras.user.js
@@ -92,6 +92,8 @@ class FindAGraveMemorial {
 
   get firstName() { return this.getPropertyPresence('firstName') }
   get lastName() { return this.getPropertyPresence('lastName') }
+  get lastNameAtBirth() { return this.maidenName || this.lastName }
+  get lastNameAtDeath() { return this.lastName }
   get maidenName() {
     return this.potentialSurnames.find(n => n && n != this.lastName)
   }
@@ -128,19 +130,16 @@ class FamilySearchRecordQuery {
 
   get birthLikePlace() { return encodeURI(this.memorial.birthPlace || '') }
   get birthLikeDate() { return this.memorial.birthYear || '' }
-  get birthSurname() {
-    return encodeURI(this.memorial.maidenName || this.memorial.lastname || '');
-  }
   get deathLikePlace() { return encodeURI(this.memorial.deathPlace || '') }
   get deathLikeDate() { return this.memorial.deathYear || '' }
-  get deathSurname() { return encodeURI(this.memorial.lastName || '') }
   get givenName() { return encodeURI(this.memorial.firstName || '') }
-  get surname() { return encodeURI(this.memorial.lastName || '') }
+  get surname() { return encodeURI(this.memorial.lastNameAtBirth || '') }
+  get surname1() { return encodeURI(this.memorial.lastNameAtDeath || '') }
 
   get url() {
     let _url = `${FamilySearchRecordQuery.rootUrl}?` +
       `q.givenName=${this.givenName}&` +
-      `q.surname=${this.birthSurname}&` +
+      `q.surname=${this.surname}&` +
       `q.birthLikePlace=${this.birthLikePlace}&` +
       `q.birthLikeDate.from=${this.birthLikeDate}&` +
       `q.birthLikeDate.to=${this.birthLikeDate}&` +
@@ -148,8 +147,8 @@ class FamilySearchRecordQuery {
       `q.deathLikeDate.from=${this.deathLikeDate}&` +
       `q.deathLikeDate.to=${this.deathLikeDate}`;
 
-    if (this.birthSurname != this.deathSurname) {
-      _url += `&q.surname.1=${this.deathSurname}`
+    if (this.surname != this.surname1) {
+      _url += `&q.surname.1=${this.surname1}`
     }
 
     return _url;
@@ -161,8 +160,8 @@ class FamilySearchTreeQuery {
   static rootUrl = "https://www.familysearch.org/tree/find/name";
 
   get alternateName1() {
-    if (this.memorial.lastName == this.memorial.maidenName) return "";
-    return ["", encodeURI(this.memorial.lastName), "0", "0"].join(encodeURI("|"));
+    if (this.memorial.lastNameAtBirth == this.memorial.lastNameAtDeath) return "";
+    return ["", encodeURI(this.memorial.lastNameAtDeath), "0", "0"].join(encodeURI("|"));
   }
 
   get birth() {
@@ -182,11 +181,9 @@ class FamilySearchTreeQuery {
   }
 
   get self() {
-    let surname = this.memorial.maidenName || this.memorial.lastName;
-
     return([
       encodeURI(this.memorial.firstName),
-      encodeURI(surname)
+      encodeURI(this.memorial.lastNameAtBirth)
     ].join(encodeURI("|")));
   }
 

--- a/findagrave-extras.user.js
+++ b/findagrave-extras.user.js
@@ -76,7 +76,6 @@ class FindAGraveMemorial {
     return birthLocationLabel && birthLocationLabel.innerText;
   }
 
-  get birthSurname() { return this.maidenName || this.lastName }
   get birthYear() { return parseInt(this.findagrave.birthYear, 10) }
 
   get buttonContainer() {
@@ -132,12 +131,14 @@ class FamilySearchRecordQuery {
   get deathLikePlace() { return encodeURI(this.memorial.deathPlace || '') }
   get deathLikeDate() { return this.memorial.deathYear || '' }
   get givenName() { return encodeURI(this.memorial.firstName || '') }
-  get surname() { return encodeURI(this.memorial.birthSurname || '') }
+  get maidenName() { return encodeURI(this.memorial.maidenName || '') }
+  get surname() { return encodeURI(this.memorial.lastName || '') }
 
   get url() {
     return `${FamilySearchRecordQuery.rootUrl}?` +
       `q.givenName=${this.givenName}&` +
       `q.surname=${this.surname}&` +
+      `q.surname.1=${this.maidenName}&` +
       `q.birthLikePlace=${this.birthLikePlace}&` +
       `q.birthLikeDate.from=${this.birthLikeDate}&` +
       `q.birthLikeDate.to=${this.birthLikeDate}&` +
@@ -170,16 +171,21 @@ class FamilySearchTreeQuery {
   get self() {
     return([
       encodeURI(this.memorial.firstName),
-      encodeURI(this.memorial.birthSurname)
+      encodeURI(this.memorial.lastName)
     ].join(encodeURI("|")));
   }
 
   get url() {
-    return `${FamilySearchTreeQuery.rootUrl}?` +
+    let _url = `${FamilySearchTreeQuery.rootUrl}?` +
       `self=${this.self}&` +
       "gender=&" +
       `birth=${this.birth}&` +
       `death=${this.death}`;
+
+    let altName = this.memorial.maidenName;
+    if (altName) _url += `alternateName1=%7C${encodeURI(altName)}`;
+
+    return _url;
   }
 }
 

--- a/findagrave-extras.user.js
+++ b/findagrave-extras.user.js
@@ -93,7 +93,9 @@ class FindAGraveMemorial {
 
   get firstName() { return this.getPropertyPresence('firstName') }
   get lastName() { return this.getPropertyPresence('lastName') }
-  get maidenName() { return this.potentialSurnames.find(n => n != this.lastName) }
+  get maidenName() {
+    return this.potentialSurnames.find(n => n && n != this.lastName)
+  }
 
   get seeMoreMemorialLinks() {
     return(document
@@ -104,7 +106,10 @@ class FindAGraveMemorial {
   get potentialSurnames() {
     return(this._potentialSurnames ||=
       Array.from(
-        new Set(Array.from(this.seeMoreMemorialLinks).map(a => a.innerText))
+        new Set(
+          Array.from(this.seeMoreMemorialLinks)
+            .map(a => (new URL(a).searchParams.get("lastname")))
+        )
       )
     );
   }

--- a/findagrave-extras.user.js
+++ b/findagrave-extras.user.js
@@ -133,7 +133,7 @@ class FamilySearchRecordQuery {
   }
   get deathLikePlace() { return encodeURI(this.memorial.deathPlace || '') }
   get deathLikeDate() { return this.memorial.deathYear || '' }
-  get deathSurname() { return encodeURI(this.memorial.lastname || '') }
+  get deathSurname() { return encodeURI(this.memorial.lastName || '') }
   get givenName() { return encodeURI(this.memorial.firstName || '') }
   get surname() { return encodeURI(this.memorial.lastName || '') }
 

--- a/findagrave-extras.user.js
+++ b/findagrave-extras.user.js
@@ -76,6 +76,7 @@ class FindAGraveMemorial {
     return birthLocationLabel && birthLocationLabel.innerText;
   }
 
+  get birthSurname() { return this.maidenName || this.lastName }
   get birthYear() { return parseInt(this.findagrave.birthYear, 10) }
 
   get buttonContainer() {
@@ -92,6 +93,21 @@ class FindAGraveMemorial {
 
   get firstName() { return this.getPropertyPresence('firstName') }
   get lastName() { return this.getPropertyPresence('lastName') }
+  get maidenName() { return this.potentialSurnames.find(n => n != this.lastName) }
+
+  get seeMoreMemorialLinks() {
+    return(document
+      .getElementsByClassName('see-more')[0]
+      .parentElement.querySelectorAll('a[href^="/memorial/search?"]'));
+  }
+
+  get potentialSurnames() {
+    return(this._potentialSurnames ||=
+      Array.from(
+        new Set(Array.from(this.seeMoreMemorialLinks).map(a => a.innerText))
+      )
+    );
+  }
 
   get memorialElement() {
     return this._memorialElement ||= document.getElementById('memNumberLabel');
@@ -111,7 +127,7 @@ class FamilySearchRecordQuery {
   get deathLikePlace() { return encodeURI(this.memorial.deathPlace || '') }
   get deathLikeDate() { return this.memorial.deathYear || '' }
   get givenName() { return encodeURI(this.memorial.firstName || '') }
-  get surname() { return encodeURI(this.memorial.lastName || '') }
+  get surname() { return encodeURI(this.memorial.birthSurname || '') }
 
   get url() {
     return `${FamilySearchRecordQuery.rootUrl}?` +
@@ -149,7 +165,7 @@ class FamilySearchTreeQuery {
   get self() {
     return([
       encodeURI(this.memorial.firstName),
-      encodeURI(this.memorial.lastName)
+      encodeURI(this.memorial.birthSurname)
     ].join(encodeURI("|")));
   }
 

--- a/findagrave-extras.user.js
+++ b/findagrave-extras.user.js
@@ -128,29 +128,42 @@ class FamilySearchRecordQuery {
 
   get birthLikePlace() { return encodeURI(this.memorial.birthPlace || '') }
   get birthLikeDate() { return this.memorial.birthYear || '' }
+  get birthSurname() {
+    return encodeURI(this.memorial.maidenName || this.memorial.lastname || '');
+  }
   get deathLikePlace() { return encodeURI(this.memorial.deathPlace || '') }
   get deathLikeDate() { return this.memorial.deathYear || '' }
+  get deathSurname() { return encodeURI(this.memorial.lastname || '') }
   get givenName() { return encodeURI(this.memorial.firstName || '') }
-  get maidenName() { return encodeURI(this.memorial.maidenName || '') }
   get surname() { return encodeURI(this.memorial.lastName || '') }
 
   get url() {
-    return `${FamilySearchRecordQuery.rootUrl}?` +
+    let _url = `${FamilySearchRecordQuery.rootUrl}?` +
       `q.givenName=${this.givenName}&` +
-      `q.surname=${this.surname}&` +
-      `q.surname.1=${this.maidenName}&` +
+      `q.surname=${this.birthSurname}&` +
       `q.birthLikePlace=${this.birthLikePlace}&` +
       `q.birthLikeDate.from=${this.birthLikeDate}&` +
       `q.birthLikeDate.to=${this.birthLikeDate}&` +
       `q.deathLikePlace=${this.deathLikePlace}&` +
       `q.deathLikeDate.from=${this.deathLikeDate}&` +
       `q.deathLikeDate.to=${this.deathLikeDate}`;
+
+    if (this.birthSurname != this.deathSurname) {
+      _url += `&q.surname.1=${this.deathSurname}`
+    }
+
+    return _url;
   }
 }
 
 class FamilySearchTreeQuery {
   constructor(memorial) { this.memorial = memorial }
   static rootUrl = "https://www.familysearch.org/tree/find/name";
+
+  get alternateName1() {
+    if (this.memorial.lastName == this.memorial.maidenName) return "";
+    return ["", encodeURI(this.memorial.lastName), "0", "0"].join(encodeURI("|"));
+  }
 
   get birth() {
     let year = this.memorial.birthYear || "";
@@ -169,23 +182,21 @@ class FamilySearchTreeQuery {
   }
 
   get self() {
+    let surname = this.memorial.maidenName || this.memorial.lastName;
+
     return([
       encodeURI(this.memorial.firstName),
-      encodeURI(this.memorial.lastName)
+      encodeURI(surname)
     ].join(encodeURI("|")));
   }
 
   get url() {
-    let _url = `${FamilySearchTreeQuery.rootUrl}?` +
+    return `${FamilySearchTreeQuery.rootUrl}?` +
       `self=${this.self}&` +
       "gender=&" +
       `birth=${this.birth}&` +
-      `death=${this.death}`;
-
-    let altName = this.memorial.maidenName;
-    if (altName) _url += `alternateName1=%7C${encodeURI(altName)}`;
-
-    return _url;
+      `death=${this.death}&` +
+      `alternateName1=${this.alternateName1}&`;
   }
 }
 


### PR DESCRIPTION
The `findagrave` object does not expose a `birthName` or `maidenName` property so we need to look elsewhere and make a guess. This digs into the "see more" section of the page, where, among other things, it includes searches using the person's birth name. If it can figure out a birth surname through these links, it will use it in FamilySearch queries as the primary surname and then use the `lastName` (which is typically a married name) as an alternate surname.