### PR TITLE
Restore FindAGrave ID-click-to-FamilySearch

### DIFF
--- a/findagrave-extras.user.js
+++ b/findagrave-extras.user.js
@@ -19,6 +19,8 @@ class FindAGraveMemorial {
       title: 'Look up this grave on FamilySearch'
     });
     this.memorialElement.innerHTML = '';
+    this.memorialElement.classList.remove("hidden");
+    this.memorialElement.nextElementSibling.classList.add("hidden");
     return this.memorialElement.appendChild(link);
   }
 


### PR DESCRIPTION
FindAGrave changed the ID into a click-to-copy button. This hides that click-to-copy and restores the FamilySearch lookup link.