### PR TITLE
Rubydoc updates

### DIFF
--- a/rubydoc-version-switcher.user.js
+++ b/rubydoc-version-switcher.user.js
@@ -3,6 +3,7 @@
 // @description   Adds a version-switcher widget and other extras to ruby-doc.org
 // @match         https://ruby-doc.org/*
 // @run-at        document-idle
+// @version       1.0.0
 // ==/UserScript==
 
 class RubyDocExtras {

--- a/rubydoc-version-switcher.user.js
+++ b/rubydoc-version-switcher.user.js
@@ -22,8 +22,8 @@ class AnchorActionBar {
   constructor(win) { this.document = win.document }
 
   setup() {
-    let actionbar = this.document.getElementById("actionbar");
-    let contentDiv = this.document.querySelector("div.wrapper.hdiv");
+    const actionbar = this.document.getElementById("actionbar");
+    const contentDiv = this.document.querySelector("div.wrapper.hdiv");
 
     if (actionbar && contentDiv) {
       actionbar.style.position = "fixed";
@@ -62,8 +62,8 @@ class UpdateUrlOnScroll {
   get topAnchor() { return this.topAnchors[0] }
 
   setup() {
-    let self = this;
-    let updateHeading = function() {
+    const self = this;
+    const updateHeading = function() {
       if (self.topAnchor && self.currentAnchor != self.topAnchor) {
         self.currentAnchor = self.topAnchor;
         self.window.history.pushState(null, null, `#${self.currentAnchor.id}`);
@@ -88,18 +88,18 @@ class RubyVersionSelector {
     this.document = win.document;
     this.currentVersion = this.document.location.pathname.split("/")[1];
 
-    let v = new Set(RubyVersionSelector.versions);
+    const v = new Set(RubyVersionSelector.versions);
     v.add(this.currentVersion);
     this.versions = Array.from(v).sort().reverse();
   }
 
   setup() {
-    let doc = this.document;
-    let versionLink = doc.querySelectorAll("#menubar li")[1];
+    const doc = this.document;
+    const versionLink = doc.querySelectorAll("#menubar li")[1];
     if (!versionLink) return;
 
-    let li = this.document.createElement("li");
-    let select = this.document.createElement("select");
+    const li = this.document.createElement("li");
+    const select = this.document.createElement("select");
     select.style.backgroundColor = "#666";
     select.style.color = "#fff";
     select.style.border = "none";
@@ -107,7 +107,7 @@ class RubyVersionSelector {
     select.style.fontSize = "medium";
 
     this.versions.forEach(function(version) {
-      let opt = doc.createElement("option");
+      const opt = doc.createElement("option");
       opt.innerText = version;
       select.appendChild(opt);
     });
@@ -116,7 +116,7 @@ class RubyVersionSelector {
     li.appendChild(select);
 
     select.addEventListener("change", function() {
-      let urlParts = doc.location.href.split("/");
+      const urlParts = doc.location.href.split("/");
       urlParts[3] = select.value;
       doc.location.href = urlParts.join("/");
     });
@@ -126,12 +126,12 @@ class RubyVersionSelector {
 }
 
 RubyVersionSelector.fetchVersions = async function(win) {
-  let storage = win.sessionStorage;
+  const storage = win.sessionStorage;
   let current = storage.getItem('ruby-versions');
   if (current) return JSON.parse(current);
-  let html = await (await win.fetch('/')).text();
-  let parser = new DOMParser();
-  let doc = parser.parseFromString(html, 'text/html');
+  const html = await (await win.fetch('/')).text();
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
   current = Array.from(doc.querySelector('ul.main').querySelectorAll('li span a'))
     .map(a => a.pathname.replace(/^\//, ""));
 

--- a/rubydoc-version-switcher.user.js
+++ b/rubydoc-version-switcher.user.js
@@ -9,7 +9,7 @@
 class RubyDocExtras {
   static setupClasses = [];
   static onSetup(klass) { RubyDocExtras.setupClasses.push(klass) }
-  static setup(doc) { (new RubyDocExtras(doc)).setup() }
+  static setup(win) { (new RubyDocExtras(win)).setup() }
 
   constructor(win) { this.window = win }
 
@@ -64,23 +64,22 @@ class UpdateUrlOnScroll {
   get topAnchor() { return this.topAnchors[0] }
 
   setup() {
-    const self = this;
-    const updateHeading = () => {
-      if (self.topAnchor && self.currentAnchor != self.topAnchor) {
-        self.currentAnchor = self.topAnchor;
-        self.window.history.pushState(null, null, `#${self.currentAnchor.id}`);
+    const updateHeading = function () {
+      if (this.topAnchor && this.currentAnchor != this.topAnchor) {
+        this.currentAnchor = this.topAnchor;
+        this.window.history.pushState(null, null, `#${this.currentAnchor.id}`);
       }
-      else if (self.currentAnchor && self.window.scrollY == 0) {
-        self.currentAnchor = undefined;
-        self.window.history.pushState(
+      else if (this.currentAnchor && this.window.scrollY == 0) {
+        this.currentAnchor = undefined;
+        this.window.history.pushState(
           null,
           null,
-          self.window.location.pathname + self.window.location.search
+          this.window.location.pathname + this.window.location.search
         );
       }
     };
 
-    this.window.addEventListener('scroll', updateHeading);
+    this.window.addEventListener('scroll', updateHeading.bind(this));
   }
 }
 RubyDocExtras.onSetup(UpdateUrlOnScroll);

--- a/rubydoc-version-switcher.user.js
+++ b/rubydoc-version-switcher.user.js
@@ -6,16 +6,12 @@
 // @version       1.0.0
 // ==/UserScript==
 
-class RubyDocExtras {
-  static setupClasses = [];
-  static onSetup(klass) { RubyDocExtras.setupClasses.push(klass) }
-  static setup(win) { (new RubyDocExtras(win)).setup() }
-
-  constructor(win) { this.window = win }
-
-  setup() {
-    for (const callback of RubyDocExtras.setupClasses) {
-      (new callback(this.window)).setup();
+const RubyDocExtras = {
+  setupClasses: [],
+  onSetup(klass) { this.setupClasses.push(klass) },
+  setup(win) {
+    for (const klass of this.setupClasses) {
+      (new klass(win)).setup();
     }
   }
 }

--- a/rubydoc-version-switcher.user.js
+++ b/rubydoc-version-switcher.user.js
@@ -7,21 +7,14 @@
 // ==/UserScript==
 
 const RubyDocExtras = {
-  setupClasses: [],
-  onSetup(klass) { this.setupClasses.push(klass) },
+  setupFunctions: [],
+  onSetup(klass) { this.setupFunctions.push(klass) },
   setup(win) {
-    for (const klass of this.setupClasses) {
-      if (klass.setup) {
-        console.log("NEW STYLE", klass);
-        klass.setup.bind(win).call();
-      }
-      else {
-        console.log("OLD STYLE", klass);
-        (new klass(win)).setup();
-      }
+    for (const fn of this.setupFunctions) {
+      fn.setup.bind(win).call();
     }
   }
-}
+};
 
 // Make the "action bar" stick to the top of the page
 const AnchorActionBar = {
@@ -58,6 +51,10 @@ class UpdateUrlOnScroll {
       .map(a => a.el)
     );
   }
+
+  static setup() {
+    (new UpdateUrlOnScroll(this)).setup();
+  };
 
   setup() {
     const updateHeading = function () {

--- a/rubydoc-version-switcher.user.js
+++ b/rubydoc-version-switcher.user.js
@@ -26,8 +26,7 @@ class AnchorActionBar {
     const contentDiv = this.document.querySelector("div.wrapper.hdiv");
 
     if (actionbar && contentDiv) {
-      actionbar.style.position = "fixed";
-      actionbar.style.zIndex = "9999";
+      Object.assign(actionbar.style, { position: "fixed", zIndex: "9999" });
       contentDiv.style.paddingTop = "32px";
     }
   }
@@ -100,11 +99,13 @@ class RubyVersionSelector {
 
     const li = this.document.createElement("li");
     const select = this.document.createElement("select");
-    select.style.backgroundColor = "#666";
-    select.style.color = "#fff";
-    select.style.border = "none";
-    select.style.fontWeight = "bold";
-    select.style.fontSize = "medium";
+    Object.assign(select.style, {
+      backgroundColor: "#666",
+      color: "#fff",
+      border: "none",
+      fontWeight: "bold",
+      fontSize: "medium"
+    });
 
     this.versions.forEach(function(version) {
       const opt = doc.createElement("option");

--- a/rubydoc-version-switcher.user.js
+++ b/rubydoc-version-switcher.user.js
@@ -13,7 +13,9 @@ class RubyDocExtras {
   constructor(win) { this.window = win }
 
   setup() {
-    RubyDocExtras.setupClasses.forEach(cb => { (new cb(this.window)).setup() });
+    for (const callback of RubyDocExtras.setupClasses) {
+      (new callback(this.window)).setup();
+    }
   }
 }
 
@@ -48,7 +50,7 @@ class UpdateUrlOnScroll {
     return(this
       .anchorElements
       .map(e => ({ "el": e, "top": e.getBoundingClientRect().top }))
-      .sort(function (a, b) {
+      .sort((a, b) => {
         if (a.top > b.top) return 1;
         if (a.top < b.top) return -1;
         return 0;
@@ -62,7 +64,7 @@ class UpdateUrlOnScroll {
 
   setup() {
     const self = this;
-    const updateHeading = function() {
+    const updateHeading = () => {
       if (self.topAnchor && self.currentAnchor != self.topAnchor) {
         self.currentAnchor = self.topAnchor;
         self.window.history.pushState(null, null, `#${self.currentAnchor.id}`);
@@ -107,16 +109,16 @@ class RubyVersionSelector {
       fontSize: "medium"
     });
 
-    this.versions.forEach(function(version) {
+    for (const version of this.versions) {
       const opt = doc.createElement("option");
       opt.innerText = version;
       select.appendChild(opt);
-    });
+    }
     select.value = this.currentVersion;
 
     li.appendChild(select);
 
-    select.addEventListener("change", function() {
+    select.addEventListener("change", () => {
       const urlParts = doc.location.href.split("/");
       urlParts[3] = select.value;
       doc.location.href = urlParts.join("/");
@@ -126,7 +128,7 @@ class RubyVersionSelector {
   }
 }
 
-RubyVersionSelector.fetchVersions = async function(win) {
+RubyVersionSelector.fetchVersions = async (win) => {
   const storage = win.sessionStorage;
   let current = storage.getItem('ruby-versions');
   if (current) return JSON.parse(current);

--- a/rubydoc-version-switcher.user.js
+++ b/rubydoc-version-switcher.user.js
@@ -44,13 +44,10 @@ class UpdateUrlOnScroll {
     this.currentAnchor = undefined;
   }
 
-  get anchorElements() {
-    return Array.from(this.window.document.querySelectorAll("div[id^=method-].method-detail"));
-  }
-
   get topAnchors() {
-    return(this
-      .anchorElements
+    const anchorElements = Array.from(this.window.document.querySelectorAll("div[id^=method-].method-detail"));
+
+    return(anchorElements
       .map(e => ({ "el": e, "top": e.getBoundingClientRect().top }))
       .sort((a, b) => {
         if (a.top > b.top) return 1;
@@ -62,12 +59,12 @@ class UpdateUrlOnScroll {
     );
   }
 
-  get topAnchor() { return this.topAnchors[0] }
-
   setup() {
     const updateHeading = function () {
-      if (this.topAnchor && this.currentAnchor != this.topAnchor) {
-        this.currentAnchor = this.topAnchor;
+      const topAnchor = this.topAnchors[0];
+
+      if (topAnchor && this.currentAnchor != topAnchor) {
+        this.currentAnchor = topAnchor;
         this.window.history.pushState(null, null, `#${this.currentAnchor.id}`);
       }
       else if (this.currentAnchor && this.window.scrollY == 0) {


### PR DESCRIPTION
* No more lint warnings from Tampermonkey
* Rework the setup callbacks to be less `class`-centric
* Many `let`s become `const`s
* More "modernization": `for … of`, `bind` replacing closures, `=>` functions, etc.